### PR TITLE
fixes issues with whitspaces when parsing CLI args

### DIFF
--- a/pydantic_settings/sources.py
+++ b/pydantic_settings/sources.py
@@ -1175,7 +1175,7 @@ class CliSettingsSource(EnvSettingsSource, Generic[T]):
                     val = val[1:-1]
                 while val:
                     if val.startswith(','):
-                        val = self._consume_comma(val, merged_list, is_last_consumed_a_value)
+                        val = self._consume_comma(val, merged_list, is_last_consumed_a_value).strip()
                         is_last_consumed_a_value = False
                     else:
                         if val.startswith('{') or val.startswith('['):


### PR DESCRIPTION
Whitespaces in Json Lists cause issue when parsing CLI args

Tested in pydantic_settings version 2.4.0


see https://github.com/pydantic/pydantic-settings/issues/368